### PR TITLE
Add link to content on HashiCorp Learn

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # learn-terraform-circleci
-Supplemental repository for Learn content on CircleCI
+
+Supplemental repository for Learn content on CircleCI.
+
+For a full step by step guide, see the accompanying guide at [HashiCorp Learn](https://learn.hashicorp.com/terraform/development/circle).


### PR DESCRIPTION
Includes an explicit link to the corresponding guide on HashiCorp Learn.